### PR TITLE
160 bug recursion does not load function arguments for typechecking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memory-stats"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f79cf9964c5c9545493acda1263f1912f8d2c56c8a2ffee2606cb960acaacc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "mscript"
 version = "0.0.0-alpha"
 dependencies = [
@@ -345,6 +355,7 @@ dependencies = [
  "colored",
  "compiler",
  "log",
+ "memory-stats",
 ]
 
 [[package]]
@@ -599,6 +610,28 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bytecode_dev_transpiler = { path = "./bytecode_dev_transpiler" }
 compiler = { path = "./compiler" }
 log = "0.4.19"
 colored = "2.0.4"
+memory-stats = { version = "1.1.0", features = ["always_use_statm"]}
 
 [features]
 default = ["skip_breakpoint"]

--- a/bytecode/src/file.rs
+++ b/bytecode/src/file.rs
@@ -209,7 +209,8 @@ impl MScriptFile {
     fn get_functions(self: &Rc<Self>) -> Result<Functions> {
         let path = self.path();
         let mut reader = BufReader::new(
-            File::open(&*path).with_context(|| format!("failed opening file `{path}` ({self:?})"))?,
+            File::open(&*path)
+                .with_context(|| format!("failed opening file `{path}` ({self:?})"))?,
         );
         let mut buffer = Vec::new();
 

--- a/bytecode/src/file.rs
+++ b/bytecode/src/file.rs
@@ -166,8 +166,8 @@ impl MScriptFile {
     }
 
     /// Get the path of the file.
-    pub fn path(&self) -> &String {
-        &self.path
+    pub fn path(&self) -> Rc<String> {
+        self.path.clone()
     }
 
     /// Get a shared reference to the underlying path pointer.
@@ -209,7 +209,7 @@ impl MScriptFile {
     fn get_functions(self: &Rc<Self>) -> Result<Functions> {
         let path = self.path();
         let mut reader = BufReader::new(
-            File::open(path).with_context(|| format!("failed opening file `{path}` ({self:?})"))?,
+            File::open(&*path).with_context(|| format!("failed opening file `{path}` ({self:?})"))?,
         );
         let mut buffer = Vec::new();
 

--- a/bytecode/src/function.rs
+++ b/bytecode/src/function.rs
@@ -73,7 +73,7 @@ impl PrimitiveFunction {
     }
 
     /// Get the location of the function.
-    pub(crate) fn location(&self) -> &String {
+    pub(crate) fn location(&self) -> &str {
         &self.location
     }
 
@@ -412,8 +412,8 @@ impl Function {
     }
 
     /// Get a function's name.
-    pub(crate) fn name(&self) -> &String {
-        &self.name
+    pub(crate) fn name(&self) -> Rc<String> {
+        self.name.clone()
     }
 
     /// Get a function's location.

--- a/bytecode/src/instruction.rs
+++ b/bytecode/src/instruction.rs
@@ -552,7 +552,7 @@ pub mod implementations {
         };
 
         let function = ctx.owner();
-        let name = Rc::new(function.name().clone());
+        let name = function.name();
 
         let obj = unsafe {
             if !OBJECT_BUILDER.has_class_been_registered(&name) {
@@ -723,7 +723,7 @@ pub mod implementations {
                 bail!("missing argument, and the last item in the local stack ({last:?}, S:{:#?}) is not a function.", ctx.get_local_operating_stack())
             };
 
-            let destination = JumpRequestDestination::Standard(f.location().clone());
+            let destination = JumpRequestDestination::Standard(f.location().to_owned());
 
             let callback_state = f.callback_state().clone();
 

--- a/bytecode/src/variables/ops/add.rs
+++ b/bytecode/src/variables/ops/add.rs
@@ -30,7 +30,7 @@ impl std::ops::Add for &Primitive {
                 x.extend_from_slice(y.borrow().as_ref());
                 vector!(raw x)
             }
-            _ => bail!("valid ops: number + number, str + any, any + str, vec + vec"),
+            (x, y) => bail!("<{:?} + {:?}> is invalid. (valid ops are: <num + num>, <str + any>, <any + str>, <vec + vec>", x.ty(), y.ty()),
         })
     }
 }

--- a/bytecode/src/variables/ops/div.rs
+++ b/bytecode/src/variables/ops/div.rs
@@ -30,7 +30,11 @@ impl std::ops::Div for &Primitive {
         if let Some(result) = math {
             Ok(result)
         } else {
-            bail!("<{:?} / {:?}> is invalid. (valid ops are: <num / num>)", t1.ty(), t2.ty());
+            bail!(
+                "<{:?} / {:?}> is invalid. (valid ops are: <num / num>)",
+                t1.ty(),
+                t2.ty()
+            );
         }
     }
 }

--- a/bytecode/src/variables/ops/div.rs
+++ b/bytecode/src/variables/ops/div.rs
@@ -30,7 +30,7 @@ impl std::ops::Div for &Primitive {
         if let Some(result) = math {
             Ok(result)
         } else {
-            bail!("valid ops: number / number")
+            bail!("<{:?} / {:?}> is invalid. (valid ops are: <num / num>)", t1.ty(), t2.ty());
         }
     }
 }

--- a/bytecode/src/variables/ops/mul.rs
+++ b/bytecode/src/variables/ops/mul.rs
@@ -46,7 +46,7 @@ impl std::ops::Mul for &Primitive {
             (Vector(ref x), BigInt(y)) => {
                 vector!(raw repeat_vec(x.borrow().as_ref(), (*y).try_into()?)?)
             }
-            _ => bail!("valid ops: number * number, str * number, vec * number"),
+            (x, y) => bail!("<{:?} * {:?}> is invalid. (valid ops are: <num * num>, <str * int>, <str * bigint>, <int * str>, <bigint * str>, <vec * int>, <vec * bigint>)", x.ty(), y.ty()),
         })
     }
 }

--- a/bytecode/src/variables/ops/rem.rs
+++ b/bytecode/src/variables/ops/rem.rs
@@ -31,7 +31,7 @@ impl std::ops::Rem for &Primitive {
         if let Some(result) = math {
             Ok(result)
         } else {
-            bail!("valid ops: number % number")
+            bail!("<{:?} % {:?}> is invalid. (valid ops are: <num % num>)", t1.ty(), t2.ty());
         }
     }
 }

--- a/bytecode/src/variables/ops/rem.rs
+++ b/bytecode/src/variables/ops/rem.rs
@@ -31,7 +31,11 @@ impl std::ops::Rem for &Primitive {
         if let Some(result) = math {
             Ok(result)
         } else {
-            bail!("<{:?} % {:?}> is invalid. (valid ops are: <num % num>)", t1.ty(), t2.ty());
+            bail!(
+                "<{:?} % {:?}> is invalid. (valid ops are: <num % num>)",
+                t1.ty(),
+                t2.ty()
+            );
         }
     }
 }

--- a/bytecode/src/variables/ops/sub.rs
+++ b/bytecode/src/variables/ops/sub.rs
@@ -20,7 +20,7 @@ impl std::ops::Sub for &Primitive {
         if let Some(result) = math {
             Ok(result)
         } else {
-            bail!("valid ops: number - number")
+            bail!("<{:?} - {:?}> is invalid. (valid ops are: <num - num>)", t1.ty(), t2.ty());
         }
     }
 }

--- a/bytecode/src/variables/ops/sub.rs
+++ b/bytecode/src/variables/ops/sub.rs
@@ -20,7 +20,11 @@ impl std::ops::Sub for &Primitive {
         if let Some(result) = math {
             Ok(result)
         } else {
-            bail!("<{:?} - {:?}> is invalid. (valid ops are: <num - num>)", t1.ty(), t2.ty());
+            bail!(
+                "<{:?} - {:?}> is invalid. (valid ops are: <num - num>)",
+                t1.ty(),
+                t2.ty()
+            );
         }
     }
 }

--- a/bytecode/src/variables/primitive.rs
+++ b/bytecode/src/variables/primitive.rs
@@ -26,6 +26,7 @@ macro_rules! primitive {
 
         #[derive(Debug, Eq, PartialEq, Clone)]
         pub enum Type {
+            Nil,
             $(
                 $variant,
             )*
@@ -34,6 +35,7 @@ macro_rules! primitive {
         impl Primitive {
             pub fn ty(&self) -> Type {
                 match self {
+                    Primitive::Optional(None) => Type::Nil,
                     $(
                         Primitive::$variant(_) => Type::$variant,
                     )*

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -541,7 +541,7 @@ impl PartialEq for Dependency<'_> {
 }
 
 impl<'a> Dependency<'a> {
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         self.ident.as_ref().name()
     }
     pub const fn new(ident: Cow<'a, Ident>) -> Self {

--- a/compiler/src/ast/class.rs
+++ b/compiler/src/ast/class.rs
@@ -4,7 +4,7 @@ mod constructor;
 mod member_function;
 mod member_variable;
 
-use std::{borrow::Cow, fmt::Display, path::PathBuf, rc::Rc, sync::Arc};
+use std::{borrow::Cow, fmt::Display, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 
@@ -137,7 +137,7 @@ impl ClassType {
 
         // use default constructor if a class doesn't have one.
 
-        let empty_parameters = Rc::new(FunctionParameters::TypesOnly(vec![]));
+        let empty_parameters = Arc::new(FunctionParameters::TypesOnly(vec![]));
 
         FunctionType::new(empty_parameters, return_type)
     }
@@ -259,7 +259,7 @@ impl Parser {
         };
 
         input.user_data().add_type(
-            ident.name().clone().into_boxed_str(),
+            ident.name().into(),
             ident.ty().unwrap().clone().into_owned(),
         );
 

--- a/compiler/src/ast/class.rs
+++ b/compiler/src/ast/class.rs
@@ -4,7 +4,7 @@ mod constructor;
 mod member_function;
 mod member_variable;
 
-use std::{borrow::Cow, fmt::Display, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, fmt::Display, path::PathBuf, sync::Arc, rc::Rc};
 
 use anyhow::Result;
 
@@ -137,7 +137,7 @@ impl ClassType {
 
         // use default constructor if a class doesn't have one.
 
-        let empty_parameters = Arc::new(FunctionParameters::TypesOnly(vec![]));
+        let empty_parameters = Rc::new(FunctionParameters::TypesOnly(vec![]));
 
         FunctionType::new(empty_parameters, return_type)
     }

--- a/compiler/src/ast/class.rs
+++ b/compiler/src/ast/class.rs
@@ -4,7 +4,7 @@ mod constructor;
 mod member_function;
 mod member_variable;
 
-use std::{borrow::Cow, fmt::Display, path::PathBuf, sync::Arc, rc::Rc};
+use std::{borrow::Cow, fmt::Display, path::PathBuf, rc::Rc, sync::Arc};
 
 use anyhow::Result;
 

--- a/compiler/src/ast/class/constructor.rs
+++ b/compiler/src/ast/class/constructor.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, path::PathBuf, sync::Arc, rc::Rc};
 
 use anyhow::Result;
 use bytecode::compilation_bridge::id::{MAKE_FUNCTION, RET};
@@ -17,7 +17,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Constructor {
-    parameters: Arc<FunctionParameters>,
+    parameters: Rc<FunctionParameters>,
     body: Block,
     path_str: Arc<PathBuf>,
     class_name: Arc<String>,
@@ -30,7 +30,7 @@ impl Constructor {
 
     pub fn default_constructor(path_str: Arc<PathBuf>, class_name: Arc<String>) -> Self {
         Self {
-            parameters: Arc::new(FunctionParameters::Named(vec![Ident::new(
+            parameters: Rc::new(FunctionParameters::Named(vec![Ident::new(
                 "self".to_owned(),
                 Some(Cow::Owned(TypeLayout::ClassSelf)),
                 true,
@@ -116,7 +116,7 @@ impl WalkForType for Constructor {
         let parameters = input.children().next().unwrap();
         let parameters = Parser::function_parameters(parameters, false, true, true)?;
 
-        let function_type = FunctionType::new(Arc::new(parameters), ScopeReturnStatus::Void);
+        let function_type = FunctionType::new(Rc::new(parameters), ScopeReturnStatus::Void);
 
         let ident = Ident::new(
             "$constructor".to_owned(),
@@ -156,7 +156,7 @@ impl Parser {
         // Using "_" or not saving it as a variable causes the scope to pop instantly.
         let _scope_handle = input.user_data().push_function(ScopeReturnStatus::Void);
 
-        let parameters = Arc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
+        let parameters = Rc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
 
         let body = children.next().unwrap();
         let body = Self::block(body)?;

--- a/compiler/src/ast/class/constructor.rs
+++ b/compiler/src/ast/class/constructor.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf, rc::Rc, sync::Arc};
+use std::{borrow::Cow, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use bytecode::compilation_bridge::id::{MAKE_FUNCTION, RET};
@@ -17,7 +17,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Constructor {
-    parameters: FunctionParameters,
+    parameters: Arc<FunctionParameters>,
     body: Block,
     path_str: Arc<PathBuf>,
     class_name: Arc<String>,
@@ -30,11 +30,11 @@ impl Constructor {
 
     pub fn default_constructor(path_str: Arc<PathBuf>, class_name: Arc<String>) -> Self {
         Self {
-            parameters: FunctionParameters::Named(vec![Ident::new(
+            parameters: Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "self".to_owned(),
                 Some(Cow::Owned(TypeLayout::ClassSelf)),
                 true,
-            )]),
+            )])),
             body: Block::empty_body(),
             path_str,
             class_name,
@@ -76,7 +76,7 @@ impl Compile for Constructor {
         arguments.push(format!("{x}#{id}"));
 
         for dependency in dependencies {
-            arguments.push(dependency.name().clone());
+            arguments.push(dependency.name().to_owned());
         }
 
         let arguments = arguments.into_boxed_slice();
@@ -116,7 +116,7 @@ impl WalkForType for Constructor {
         let parameters = input.children().next().unwrap();
         let parameters = Parser::function_parameters(parameters, false, true, true)?;
 
-        let function_type = FunctionType::new(Rc::new(parameters), ScopeReturnStatus::Void);
+        let function_type = FunctionType::new(Arc::new(parameters), ScopeReturnStatus::Void);
 
         let ident = Ident::new(
             "$constructor".to_owned(),
@@ -131,7 +131,7 @@ impl WalkForType for Constructor {
 impl IntoType for Constructor {
     fn for_type(&self) -> Result<crate::ast::TypeLayout> {
         let function_type =
-            FunctionType::new(Rc::new(self.parameters.clone()), ScopeReturnStatus::Void);
+            FunctionType::new(self.parameters.clone(), ScopeReturnStatus::Void);
 
         Ok(TypeLayout::Function(function_type))
     }
@@ -156,7 +156,7 @@ impl Parser {
         // Using "_" or not saving it as a variable causes the scope to pop instantly.
         let _scope_handle = input.user_data().push_function(ScopeReturnStatus::Void);
 
-        let parameters = Self::function_parameters(parameters, true, true, true).to_err_vec()?;
+        let parameters = Arc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
 
         let body = children.next().unwrap();
         let body = Self::block(body)?;

--- a/compiler/src/ast/class/constructor.rs
+++ b/compiler/src/ast/class/constructor.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf, sync::Arc, rc::Rc};
+use std::{borrow::Cow, path::PathBuf, rc::Rc, sync::Arc};
 
 use anyhow::Result;
 use bytecode::compilation_bridge::id::{MAKE_FUNCTION, RET};
@@ -130,8 +130,7 @@ impl WalkForType for Constructor {
 
 impl IntoType for Constructor {
     fn for_type(&self) -> Result<crate::ast::TypeLayout> {
-        let function_type =
-            FunctionType::new(self.parameters.clone(), ScopeReturnStatus::Void);
+        let function_type = FunctionType::new(self.parameters.clone(), ScopeReturnStatus::Void);
 
         Ok(TypeLayout::Function(function_type))
     }
@@ -156,7 +155,8 @@ impl Parser {
         // Using "_" or not saving it as a variable causes the scope to pop instantly.
         let _scope_handle = input.user_data().push_function(ScopeReturnStatus::Void);
 
-        let parameters = Rc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
+        let parameters =
+            Rc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
 
         let body = children.next().unwrap();
         let body = Self::block(body)?;

--- a/compiler/src/ast/class/member_function.rs
+++ b/compiler/src/ast/class/member_function.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, path::PathBuf, sync::Arc, rc::Rc};
 
 use anyhow::Result;
 use bytecode::compilation_bridge::id::{MAKE_FUNCTION, RET};
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct MemberFunction {
     ident: Ident,
-    parameters: Arc<FunctionParameters>,
+    parameters: Rc<FunctionParameters>,
     body: Block,
     path_str: Arc<PathBuf>,
     class_name: Arc<String>,
@@ -94,7 +94,7 @@ impl WalkForType for MemberFunction {
             ScopeReturnStatus::Void
         };
 
-        let function_type = FunctionType::new(Arc::new(parameters), return_type);
+        let function_type = FunctionType::new(Rc::new(parameters), return_type);
 
         ident.link_force_no_inherit(
             input.user_data(),
@@ -145,7 +145,7 @@ impl Parser {
         // Using "_" or not saving it as a variable causes the scope to pop instantly.
         let _scope_handle = input.user_data().push_function(return_type.clone());
 
-        let parameters = Arc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
+        let parameters = Rc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
         let body = Self::block(body)?;
         let function_type = FunctionType::new(parameters.clone(), return_type);
 

--- a/compiler/src/ast/class/member_function.rs
+++ b/compiler/src/ast/class/member_function.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf, sync::Arc, rc::Rc};
+use std::{borrow::Cow, path::PathBuf, rc::Rc, sync::Arc};
 
 use anyhow::Result;
 use bytecode::compilation_bridge::id::{MAKE_FUNCTION, RET};
@@ -145,7 +145,8 @@ impl Parser {
         // Using "_" or not saving it as a variable causes the scope to pop instantly.
         let _scope_handle = input.user_data().push_function(return_type.clone());
 
-        let parameters = Rc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
+        let parameters =
+            Rc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
         let body = Self::block(body)?;
         let function_type = FunctionType::new(parameters.clone(), return_type);
 

--- a/compiler/src/ast/function.rs
+++ b/compiler/src/ast/function.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Display, hash::Hash, path::PathBuf, sync::Arc, rc::Rc};
+use std::{borrow::Cow, fmt::Display, hash::Hash, path::PathBuf, rc::Rc, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use bytecode::compilation_bridge::id::{MAKE_FUNCTION, RET};
@@ -356,8 +356,13 @@ impl Parser {
         let parameters =
             Rc::new(Self::function_parameters(parameters, true, false, false).to_err_vec()?);
 
-        let maybe_previous = input.user_data().register_function_parameters_to_scope(parameters.clone());
-        assert!(maybe_previous.is_none(), "The function's parameters have already been set: found `{maybe_previous:?}`");
+        let maybe_previous = input
+            .user_data()
+            .register_function_parameters_to_scope(parameters.clone());
+        assert!(
+            maybe_previous.is_none(),
+            "The function's parameters have already been set: found `{maybe_previous:?}`"
+        );
 
         let body = if let Some(body) = body {
             Self::block(body)?

--- a/compiler/src/ast/function.rs
+++ b/compiler/src/ast/function.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Display, hash::Hash, path::PathBuf, rc::Rc, sync::Arc};
+use std::{borrow::Cow, fmt::Display, hash::Hash, path::PathBuf, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use bytecode::compilation_bridge::id::{MAKE_FUNCTION, RET};
@@ -18,7 +18,7 @@ use super::{
 
 #[derive(Debug)]
 pub(crate) struct Function {
-    pub parameters: Rc<FunctionParameters>,
+    pub parameters: Arc<FunctionParameters>,
     pub body: Block,
     pub return_type: ScopeReturnStatus,
     pub path_str: Arc<PathBuf>,
@@ -26,7 +26,7 @@ pub(crate) struct Function {
 
 #[derive(Debug, Clone, Eq)]
 pub(crate) struct FunctionType {
-    parameters: Rc<FunctionParameters>,
+    parameters: Arc<FunctionParameters>,
     return_type: Box<ScopeReturnStatus>,
 }
 
@@ -43,8 +43,8 @@ impl FunctionType {
         &self.parameters
     }
 
-    pub(crate) fn arced_parameters(&self) -> Rc<FunctionParameters> {
-        Rc::clone(&self.parameters)
+    pub(crate) fn arced_parameters(&self) -> Arc<FunctionParameters> {
+        Arc::clone(&self.parameters)
     }
 }
 
@@ -91,7 +91,7 @@ pub mod eq_hash_test {
     #[test]
     fn names_names() {
         let lhs = FunctionType::new(
-            Rc::new(FunctionParameters::Named(vec![Ident::new(
+            Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "a".into(),
                 Some(Cow::Owned(TypeLayout::Native(NativeType::Int))),
                 false,
@@ -99,7 +99,7 @@ pub mod eq_hash_test {
             ScopeReturnStatus::Void,
         );
         let rhs = FunctionType::new(
-            Rc::new(FunctionParameters::Named(vec![Ident::new(
+            Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "a".into(),
                 Some(Cow::Owned(TypeLayout::Native(NativeType::Int))),
                 false,
@@ -113,13 +113,13 @@ pub mod eq_hash_test {
     #[test]
     fn types_names() {
         let lhs = FunctionType::new(
-            Rc::new(FunctionParameters::TypesOnly(vec![Cow::Owned(
+            Arc::new(FunctionParameters::TypesOnly(vec![Cow::Owned(
                 TypeLayout::Native(NativeType::Int),
             )])),
             ScopeReturnStatus::Void,
         );
         let rhs = FunctionType::new(
-            Rc::new(FunctionParameters::Named(vec![Ident::new(
+            Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "a".into(),
                 Some(Cow::Owned(TypeLayout::Native(NativeType::Int))),
                 false,
@@ -133,7 +133,7 @@ pub mod eq_hash_test {
     #[test]
     fn different_names_same_types() {
         let lhs = FunctionType::new(
-            Rc::new(FunctionParameters::Named(vec![Ident::new(
+            Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "a".into(),
                 Some(Cow::Owned(TypeLayout::Native(NativeType::Int))),
                 false,
@@ -141,7 +141,7 @@ pub mod eq_hash_test {
             ScopeReturnStatus::Void,
         );
         let rhs = FunctionType::new(
-            Rc::new(FunctionParameters::Named(vec![Ident::new(
+            Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "b".into(),
                 Some(Cow::Owned(TypeLayout::Native(NativeType::Int))),
                 false,
@@ -155,7 +155,7 @@ pub mod eq_hash_test {
     #[test]
     fn return_types_at_different_stages() {
         let lhs = FunctionType::new(
-            Rc::new(FunctionParameters::Named(vec![Ident::new(
+            Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "a".into(),
                 Some(Cow::Owned(TypeLayout::Native(NativeType::Int))),
                 false,
@@ -163,7 +163,7 @@ pub mod eq_hash_test {
             ScopeReturnStatus::Should(Cow::Owned(TypeLayout::Native(NativeType::Bool))),
         );
         let rhs = FunctionType::new(
-            Rc::new(FunctionParameters::Named(vec![Ident::new(
+            Arc::new(FunctionParameters::Named(vec![Ident::new(
                 "b".into(),
                 Some(Cow::Owned(TypeLayout::Native(NativeType::Int))),
                 false,
@@ -176,15 +176,13 @@ pub mod eq_hash_test {
 }
 
 impl FunctionType {
-    pub fn new(parameters: Rc<FunctionParameters>, return_type: ScopeReturnStatus) -> Self {
+    pub fn new(parameters: Arc<FunctionParameters>, return_type: ScopeReturnStatus) -> Self {
         Self {
             parameters,
             return_type: Box::new(return_type),
         }
     }
 }
-
-// type ReturnType = Option<Box<Cow<'static, TypeLayout>>>;
 
 impl Display for FunctionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -210,7 +208,7 @@ impl Display for FunctionType {
 
 impl Function {
     pub const fn new(
-        parameters: Rc<FunctionParameters>,
+        parameters: Arc<FunctionParameters>,
         body: Block,
         return_type: ScopeReturnStatus,
         path_str: Arc<PathBuf>,
@@ -265,7 +263,7 @@ impl Function {
         arguments.push(format!("{x}#{id}"));
 
         for dependency in dependencies {
-            arguments.push(dependency.name().clone());
+            arguments.push(dependency.name().to_owned());
         }
 
         let arguments = arguments.into_boxed_slice();
@@ -331,7 +329,7 @@ impl Parser {
                 .map_err(|e| vec![anyhow!(e)])?;
 
             return Ok(Function::new(
-                Rc::new(parameters),
+                Arc::new(parameters),
                 Block::empty_body(),
                 ScopeReturnStatus::Void,
                 path_str,
@@ -356,9 +354,10 @@ impl Parser {
             .push_function(ScopeReturnStatus::detect_should_return(return_type));
 
         let parameters =
-            Rc::new(Self::function_parameters(parameters, true, false, false).to_err_vec()?);
+            Arc::new(Self::function_parameters(parameters, true, false, false).to_err_vec()?);
 
-        // input.user_data().register_function_parameters_to_scope(Arc::clone(&parameters));
+        let maybe_previous = input.user_data().register_function_parameters_to_scope(parameters.clone());
+        assert!(maybe_previous.is_none(), "The function's parameters have already been set: found `{maybe_previous:?}`");
 
         let body = if let Some(body) = body {
             Self::block(body)?

--- a/compiler/src/ast/ident.rs
+++ b/compiler/src/ast/ident.rs
@@ -100,7 +100,7 @@ impl Ident {
         Ok(self)
     }
 
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         &self.name
     }
 

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -621,10 +621,18 @@ fn parse_expr(
                         let (ident, is_callback) = user_data
                             .get_dependency_flags_from_name(raw_string)
                             .with_context(|| {
+                                let hint = match primary.as_str() {
+                                    "print" => "\n    + hint: printing in MScript v1 uses the `print` keyword, like\n    +\n    +   print \"Hello World\"\n    +",
+                                    "null" => " (hint: an empty optional in MScript is represented by the `nil` keyword)",
+                                    "True" => " (hint: a truthy boolean value in MScript is represented by the `true` keyword)",
+                                    "False" => " (hint: a falsey boolean value in MScript is represented by the `false` keyword)",
+                                    _ => ""
+                                };
+
                                 new_err(
                                     primary.as_span(),
                                     &file_name,
-                                    "use of undeclared variable".into(),
+                                    format!("use of undeclared variable{hint}"),
                                 )
                             })
                             .to_err_vec()?;

--- a/compiler/src/ast/type.rs
+++ b/compiler/src/ast/type.rs
@@ -13,7 +13,6 @@ use std::{
     hash::Hash,
     ops::Deref,
     path::PathBuf,
-    rc::Rc,
     sync::Arc,
 };
 
@@ -915,7 +914,7 @@ impl Parser {
                 None
             };
 
-        let types = Rc::new(FunctionParameters::TypesOnly(types));
+        let types = Arc::new(FunctionParameters::TypesOnly(types));
 
         Ok(FunctionType::new(
             types,

--- a/compiler/src/ast/type.rs
+++ b/compiler/src/ast/type.rs
@@ -13,7 +13,8 @@ use std::{
     hash::Hash,
     ops::Deref,
     path::PathBuf,
-    sync::Arc, rc::Rc,
+    rc::Rc,
+    sync::Arc,
 };
 
 use super::{

--- a/compiler/src/ast/type.rs
+++ b/compiler/src/ast/type.rs
@@ -13,7 +13,7 @@ use std::{
     hash::Hash,
     ops::Deref,
     path::PathBuf,
-    sync::Arc,
+    sync::Arc, rc::Rc,
 };
 
 use super::{
@@ -914,7 +914,7 @@ impl Parser {
                 None
             };
 
-        let types = Arc::new(FunctionParameters::TypesOnly(types));
+        let types = Rc::new(FunctionParameters::TypesOnly(types));
 
         Ok(FunctionType::new(
             types,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -610,14 +610,14 @@ fn perform_file_io_out(
 
 pub(crate) fn perform_file_io_in(input_path: &Path) -> Result<String> {
     let Some(ext) = input_path.extension() else {
-        bail!("no file extension");
+        bail!("MScript uses `.ms` file extensions. Please add this file extension.");
     };
 
     if ext != "ms" {
         bail!("MScript uses `.ms` file extensions. Please check your file extensions.");
     }
 
-    let file = File::open(input_path).context("Could not open file for parsing :(")?;
+    let file = File::open(input_path).with_context(|| format!("Could not open {input_path:?}"))?;
 
     let mut reader = BufReader::new(file);
 

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -92,7 +92,7 @@ impl AssocFileData {
         bail!("no loop found")
     }
 
-    pub fn register_function_parameters_to_scope(&self, parameters: Arc<FunctionParameters>) -> Option<Arc<FunctionParameters>> {
+    pub fn register_function_parameters_to_scope(&self, parameters: Rc<FunctionParameters>) -> Option<Rc<FunctionParameters>> {
         self.scopes.register_function_parameters(parameters)
     }
 
@@ -232,7 +232,7 @@ impl AssocFileData {
 
     pub fn get_current_executing_function(
         &self,
-    ) -> Result<(Ref<Scope>, Ref<Arc<FunctionParameters>>)> {
+    ) -> Result<(Ref<Scope>, Ref<Rc<FunctionParameters>>)> {
         let iter = self.scopes.iter();
 
         for scope in iter {

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -92,6 +92,10 @@ impl AssocFileData {
         bail!("no loop found")
     }
 
+    pub fn register_function_parameters_to_scope(&self, parameters: Arc<FunctionParameters>) -> Option<Arc<FunctionParameters>> {
+        self.scopes.register_function_parameters(parameters)
+    }
+
     pub fn was_path_preloaded(&self, path: impl AsRef<Path>) -> bool {
         self.files.preloaded_file_exists(&path.bytecode_str())
     }
@@ -250,6 +254,7 @@ impl AssocFileData {
                                 return None;
                             }
                         }
+                        
                         unreachable!("function parameters should have been initialized");
                     };
 

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -92,7 +92,10 @@ impl AssocFileData {
         bail!("no loop found")
     }
 
-    pub fn register_function_parameters_to_scope(&self, parameters: Rc<FunctionParameters>) -> Option<Rc<FunctionParameters>> {
+    pub fn register_function_parameters_to_scope(
+        &self,
+        parameters: Rc<FunctionParameters>,
+    ) -> Option<Rc<FunctionParameters>> {
         self.scopes.register_function_parameters(parameters)
     }
 
@@ -254,7 +257,7 @@ impl AssocFileData {
                                 return None;
                             }
                         }
-                        
+
                         unreachable!("function parameters should have been initialized");
                     };
 

--- a/compiler/src/scope.rs
+++ b/compiler/src/scope.rs
@@ -3,7 +3,7 @@ use std::{
     cell::{Ref, RefCell},
     collections::{HashMap, HashSet},
     fmt::Display,
-    sync::Arc,
+    rc::Rc,
 };
 
 use anyhow::{bail, Result};
@@ -13,7 +13,7 @@ use crate::ast::{ClassType, FunctionParameters, Ident, StrWrapper, TypeLayout};
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub(crate) enum ScopeType {
     File,
-    Function(Option<Arc<FunctionParameters>>),
+    Function(Option<Rc<FunctionParameters>>),
     IfBlock,
     ElseBlock,
     WhileLoop,
@@ -206,7 +206,10 @@ impl Scopes {
         x.last_mut().unwrap().add_type(name, ty);
     }
 
-    pub(crate) fn register_function_parameters(&self, parameters: Arc<FunctionParameters>) -> Option<Arc<FunctionParameters>> {
+    pub(crate) fn register_function_parameters(
+        &self,
+        parameters: Rc<FunctionParameters>,
+    ) -> Option<Rc<FunctionParameters>> {
         let mut view = self.0.borrow_mut();
         for scope in view.iter_mut().rev() {
             if let ScopeType::Function(ref mut function) = scope.ty {

--- a/compiler/src/scope.rs
+++ b/compiler/src/scope.rs
@@ -119,15 +119,6 @@ impl SuccessTypeSearchResult<'_> {
             Self::InScope(x) => Cow::Owned(x.clone()),
         }
     }
-
-    // #[allow(unused)]
-    // pub fn unwrap(self) -> TypeLayout {
-    //     match self {
-    //         // Self::Primitive(x) => x.to_owned(),
-    //         Self::Owned(x) => x,
-    //         Self::InScope(x) => x.clone(),
-    //     }
-    // }
 }
 
 impl<'a> std::ops::Deref for TypeSearchResult<'a> {
@@ -213,6 +204,18 @@ impl Scopes {
         let mut x = self.0.borrow_mut();
 
         x.last_mut().unwrap().add_type(name, ty);
+    }
+
+    pub(crate) fn register_function_parameters(&self, parameters: Arc<FunctionParameters>) -> Option<Arc<FunctionParameters>> {
+        let mut view = self.0.borrow_mut();
+        for scope in view.iter_mut().rev() {
+            if let ScopeType::Function(ref mut function) = scope.ty {
+                let result = function.take();
+                *function = Some(parameters);
+                return result;
+            }
+        }
+        None
     }
 
     pub(crate) fn get_type_from_str(&self, str: &str) -> TypeSearchResult {

--- a/examples/main/recursion/recursive.mmm
+++ b/examples/main/recursion/recursive.mmm
@@ -1,0 +1,26 @@
+function __fn0
+	int 1
+	bin_op_assign += c
+	printn *
+	void
+	breakpoint "CALL PREINIT args"
+	breakpoint "CALL POSTINIT args"
+	call_self
+	void
+	void
+	ret
+end
+function __module__
+	int 0
+	store c
+	make_function ./recursive.mmm#__fn0 c
+	store r
+	load r
+	store_fast #1
+	breakpoint "CALL PREINIT args"
+	breakpoint "CALL POSTINIT args"
+	load_fast #1
+	call
+	void
+	ret_mod
+end

--- a/examples/main/recursion/recursive.ms
+++ b/examples/main/recursion/recursive.ms
@@ -1,0 +1,7 @@
+c = 0
+
+r = fn() {
+	print c += 1
+	self()
+}
+r()

--- a/examples/main/turing/idk.ms
+++ b/examples/main/turing/idk.ms
@@ -1,0 +1,3 @@
+const x = 10
+a: int? = nil
+print x / a

--- a/examples/main/turing/main.ms
+++ b/examples/main/turing/main.ms
@@ -1,1 +1,16 @@
 
+
+factorial = fn(input: int) -> bigint {
+	result = B1
+
+	from 1 through input, i {
+		result *= i
+	}
+
+	return result
+}
+
+print factorial(5)
+
+maybe: int? = nil
+print maybe + 1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,28 +22,32 @@ pub enum CompilationTargets {
 pub enum Commands {
     /// Compile and Run a `.ms` file.
     Run {
-        /// this is the path to a `.ms` file
+        /// This is the path to a `.ms` file
         #[arg(required(true), index = 1)]
         path: String,
-        /// the stack size, in bytes, allocated to the interpreter. 4 MB default: 4 * 1024 * 1024
+        /// The stack size, in bytes, allocated to the runtime. 4 MB default: 4 * 1024 * 1024
         #[arg(short = 'X', long = "stack-size", default_value = "4194304")]
         stack_size: usize,
-        /// print extra compilation information, but slows down the process considerably.
+        /// Print extra compilation information, but slows down the process considerably.
         #[arg(long = "verbose", default_value = "false")]
         verbose: bool,
-        /// no debug or display info besides the minimum.
-        #[arg(long = "quick", default_value = "false")]
+        /// No debug or display info besides the minimum.
+        #[arg(short = 'q', long = "quick", default_value = "false")]
         quick: bool,
+        /// Override any display settings related to the progress bars and disable them.
         #[arg(long = "no-pb", default_value = "false")]
         override_no_pb: bool,
+        /// Profile the runtime and memory usage of a program.
+        #[arg(long = "profile", default_value = "false")]
+        profile: bool,
     },
-    /// Build the interpreter and have it look for the
-    /// entrypoint of a `.mmm` file
+    /// Spawn an interpreter and have it execute the module
+    /// entrypoint of a compiled MScript `.mmm` file
     Execute {
-        /// this is the path to the file
+        /// This is the path to the file
         #[arg(required(true), index = 1)]
         path: String,
-        /// the stack size, in bytes, allocated to the interpreter. 4 MB default: 4 * 1024 * 1024
+        /// The stack size, in bytes, allocated to the interpreter. 4 MB default: 4 * 1024 * 1024
         #[arg(short = 'X', long = "stack-size", default_value = "4194304")]
         stack_size: usize,
         /// This flag looks for an input path ending in `.transpiled.mmm` and will transpile it before executing.
@@ -52,13 +56,13 @@ pub enum Commands {
     },
     /// Compile a `.ms` file into executable bytecode.
     Compile {
-        /// this is the path to the file
+        /// This is the path to the file
         #[arg(required(true))]
         path: String,
-        /// what should the compiler output: `.transpiled.mmm` human-readable bytecode, or `.mmm` machine code.
+        /// What should the compiler output: `.transpiled.mmm` human-readable bytecode, or `.mmm` machine code.
         #[arg(value_enum, default_value = "binary", long = "output-format")]
         output_format: CompilationTargets,
-        /// print extra compilation information, but slows down the process considerably.
+        /// Print extra compilation information, but slows down the process considerably.
         #[arg(long = "verbose", default_value = "false")]
         verbose: bool,
         /// No debug or display info besides the minimum.
@@ -68,7 +72,7 @@ pub enum Commands {
     /// Transpile human-readable bytecode (`.transpiled.mmm` extension)
     /// into an executable `.mmm` file.
     Transpile {
-        /// this is the path to the file
+        /// This is the path to the file
         #[arg(required(true), index = 1)]
         path: String,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,10 +139,8 @@ fn main() -> Result<()> {
                 bail!("Error initializing logger: {err:?}")
             };
 
-            // let output_path = is_path_source(&path)?;
-
             let builder = thread::Builder::new()
-                .name("Main".into())
+                .name("mscript-runtime".into())
                 .stack_size(stack_size);
 
             let main_thread = builder.spawn(move || -> Result<()> {
@@ -168,7 +166,7 @@ fn main() -> Result<()> {
             transpile_first,
         } => {
             let builder = thread::Builder::new()
-                .name("Main".into())
+                .name("mscript-runtime".into())
                 .stack_size(stack_size);
 
             let main_thread = builder.spawn(move || -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ use std::{
     path::{Path, PathBuf},
     rc::Rc,
     sync::Mutex,
-    thread, time::Instant,
+    thread,
+    time::Instant,
 };
 
 use crate::cli::CompilationTargets;
@@ -128,17 +129,13 @@ fn main() -> Result<()> {
             verbose,
             quick,
             override_no_pb,
-            profile
+            profile,
         } => {
             if verbose && !quick {
                 LOGGER.set_verbose();
             }
 
-            let start = if profile {
-                Some(Instant::now())
-            } else {
-                None
-            };
+            let start = if profile { Some(Instant::now()) } else { None };
 
             if let Err(err) =
                 log::set_logger(&LOGGER).map(|()| log::set_max_level(LevelFilter::Trace))
@@ -169,11 +166,25 @@ fn main() -> Result<()> {
 
             if let (maybe_profile, Some(start)) = (memory_stats::memory_stats(), start) {
                 let duration = Instant::now().duration_since(start);
-                
-                println!("{}", format!("\nExecution Profile:\n  Program finished in {}s", duration.as_secs_f32()).black());
-                
+
+                println!(
+                    "{}",
+                    format!(
+                        "\nExecution Profile:\n  Program finished in {}s",
+                        duration.as_secs_f32()
+                    )
+                    .black()
+                );
+
                 if let Some(profile) = maybe_profile {
-                    println!("{}", format!("    Physical memory: {} bytes\n    Virtual memory: {} bytes\n", profile.physical_mem, profile.virtual_mem).black());
+                    println!(
+                        "{}",
+                        format!(
+                            "    Physical memory: {} bytes\n    Virtual memory: {} bytes\n",
+                            profile.physical_mem, profile.virtual_mem
+                        )
+                        .black()
+                    );
                 } else {
                     println!("{}", "    <system does not support memory stats>\n".red())
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ fn main() -> Result<()> {
                         "\nExecution Profile:\n  Program finished in {}s",
                         duration.as_secs_f32()
                     )
-                    .black()
+                    .dimmed()
                 );
 
                 if let Some(profile) = maybe_profile {
@@ -183,7 +183,7 @@ fn main() -> Result<()> {
                             "    Physical memory: {} bytes\n    Virtual memory: {} bytes\n",
                             profile.physical_mem, profile.virtual_mem
                         )
-                        .black()
+                        .dimmed()
                     );
                 } else {
                     println!("{}", "    <system does not support memory stats>\n".red())


### PR DESCRIPTION
* added `--profile` CLI flag
  * uses the [Memory Stats](https://crates.io/crates/memory-stats) crate to profile the program's memory footprint.
  * <img width="433" alt="Powershell Screenshot" src="https://github.com/mrodz/mscript/assets/79176075/08c6bdf8-ee76-4f8c-a636-0236466e6ca7">
* fixed issue with `self` not having access to the executing function's parameters
* added some beginner-friendly error messages and hints