### PR TITLE
177 bug incorrectly allowing variable to be callable

### DIFF
--- a/bytecode/src/function.rs
+++ b/bytecode/src/function.rs
@@ -1002,6 +1002,12 @@ impl PrimitiveFunction {
     pub(crate) fn callback_state(&self) -> &Option<Rc<VariableMapping>> {
         &self.callback_state
     }
+
+    pub(crate) fn true_eq(&self, other: &Self) -> bool {
+        self.location == other.location
+            && self.callback_state.as_ref().map(Rc::as_ptr)
+                == other.callback_state.as_ref().map(Rc::as_ptr)
+    }
 }
 
 impl PartialEq for PrimitiveFunction {

--- a/bytecode/src/instruction.rs
+++ b/bytecode/src/instruction.rs
@@ -152,6 +152,7 @@ pub mod implementations {
             ("&", ..) => left & right,
             ("<<", ..) => left << right,
             (">>", ..) => left >> right,
+            ("is", ..) => left.runtime_addr_check(&right),
             _ => bail!("unknown operation: {symbols} (got &{left}, &{right})"),
         }
         .context("invalid binary operation")?;
@@ -324,7 +325,10 @@ pub mod implementations {
             match op_name.as_str() {
                 "reverse" => {
                     let Some(Primitive::Vector(vector)) = ctx.get_last_op_item() else {
-                        bail!("Cannot perform a vector operation on a non-vector (found: {:?})", ctx.get_last_op_item())
+                        bail!(
+                            "Cannot perform a vector operation on a non-vector (found: {:?})",
+                            ctx.get_last_op_item()
+                        )
                     };
 
                     let mut vector = vector.borrow_mut();
@@ -348,7 +352,7 @@ pub mod implementations {
                     };
 
                     let primitive = primitive.move_out_of_heap_primitive_borrow();
-                    
+
                     let Primitive::Vector(vector) = primitive.as_ref() else {
                         bail!("Cannot perform a vector operation on a non-vector (found: {primitive})")
                     };

--- a/bytecode/src/instruction.rs
+++ b/bytecode/src/instruction.rs
@@ -266,6 +266,9 @@ pub mod implementations {
             let Some(indexable) = ctx.pop() else {
                 bail!("the stack is empty");
             };
+
+            let indexable = indexable.move_out_of_heap_primitive();
+
             // this manual byte slice to usize conversion is more performant
             let idx: usize = 'index_gen: {
                 let mut idx = 0;
@@ -321,7 +324,7 @@ pub mod implementations {
             match op_name.as_str() {
                 "reverse" => {
                     let Some(Primitive::Vector(vector)) = ctx.get_last_op_item() else {
-                        bail!("Cannot perform a vector operation on a non-vector")
+                        bail!("Cannot perform a vector operation on a non-vector (found: {:?})", ctx.get_last_op_item())
                     };
 
                     let mut vector = vector.borrow_mut();
@@ -340,8 +343,14 @@ pub mod implementations {
 
                     let new_item = ctx.pop().context("could not pop first item")?;
 
-                    let Some(Primitive::Vector(vector)) = ctx.get_last_op_item() else {
-                        bail!("Cannot perform a vector operation on a non-vector")
+                    let Some(primitive) = ctx.get_last_op_item() else {
+                        bail!("Stack is empty")
+                    };
+
+                    let primitive = primitive.move_out_of_heap_primitive_borrow();
+                    
+                    let Primitive::Vector(vector) = primitive.as_ref() else {
+                        bail!("Cannot perform a vector operation on a non-vector (found: {primitive})")
                     };
 
                     let mut vector = vector.borrow_mut();

--- a/compiler/src/ast/assignment/assignment_type.rs
+++ b/compiler/src/ast/assignment/assignment_type.rs
@@ -44,8 +44,8 @@ impl Parser {
                     )
                     .unwrap_or_default();
 
-                let message = if value.is_callable().to_err_vec()? {
-                    format!("declaration wanted `{ty}`, but value is a function that returns `{assignment_ty}`{hint}")
+                let message = if let Some(as_callable) = assignment_ty.is_callable() {
+                    format!("declaration wanted `{ty}`, but value is a function that returns `{}`{hint}", as_callable.return_type())
                 } else {
                     // TODO: special check for function types.
                     format!("declaration wanted `{ty}`, but value is `{assignment_ty}`{hint}")

--- a/compiler/src/ast/class/constructor.rs
+++ b/compiler/src/ast/class/constructor.rs
@@ -116,7 +116,8 @@ impl WalkForType for Constructor {
         let parameters = input.children().next().unwrap();
         let parameters = Parser::function_parameters(parameters, false, true, true)?;
 
-        let function_type = FunctionType::new(Rc::new(parameters), ScopeReturnStatus::Void, false);
+        let function_type =
+            FunctionType::new(Rc::new(parameters), ScopeReturnStatus::Void, false, true);
 
         let ident = Ident::new(
             "$constructor".to_owned(),
@@ -130,8 +131,12 @@ impl WalkForType for Constructor {
 
 impl IntoType for Constructor {
     fn for_type(&self) -> Result<crate::ast::TypeLayout> {
-        let function_type =
-            FunctionType::new(self.parameters.clone(), ScopeReturnStatus::Void, false);
+        let function_type = FunctionType::new(
+            self.parameters.clone(),
+            ScopeReturnStatus::Void,
+            false,
+            true,
+        );
 
         Ok(TypeLayout::Function(function_type))
     }

--- a/compiler/src/ast/class/member_function.rs
+++ b/compiler/src/ast/class/member_function.rs
@@ -94,7 +94,7 @@ impl WalkForType for MemberFunction {
             ScopeReturnStatus::Void
         };
 
-        let function_type = FunctionType::new(Rc::new(parameters), return_type, true);
+        let function_type = FunctionType::new(Rc::new(parameters), return_type, true, false);
 
         ident.link_force_no_inherit(
             input.user_data(),
@@ -148,7 +148,7 @@ impl Parser {
         let parameters =
             Rc::new(Self::function_parameters(parameters, true, true, true).to_err_vec()?);
         let body = Self::block(body)?;
-        let function_type = FunctionType::new(parameters.clone(), return_type, true);
+        let function_type = FunctionType::new(parameters.clone(), return_type, true, false);
 
         ident.set_type_no_link(Cow::Owned(TypeLayout::Function(function_type)));
 

--- a/compiler/src/ast/dot_lookup.rs
+++ b/compiler/src/ast/dot_lookup.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use anyhow::Result;
+use anyhow::{Result, Context};
 
 use crate::{
     instruction,
@@ -194,7 +194,7 @@ impl Parser {
                         if ident_ty.is_class() {
                             allow_self_type = Cow::Owned(ident_ty.clone().into_owned());
                         } else {
-                            let callable_ty = ident_ty
+                            let callable_ty = dbg!(ident_ty)
                                 .is_callable()
                                 .details(
                                     input.as_span(),
@@ -228,9 +228,8 @@ impl Parser {
                 let output_type = function_type.return_type();
 
                 let output_type = output_type
-                    .get_type()
-                    .unwrap_or(&Cow::Owned(TypeLayout::Void));
-
+                    .get_type().context("this scope does not return a value, not even `void`").to_err_vec()?;
+                
                 let output_type = if output_type.is_class_self() {
                     lhs_ty_cow
                 } else {

--- a/compiler/src/ast/function_arguments.rs
+++ b/compiler/src/ast/function_arguments.rs
@@ -106,7 +106,7 @@ impl Parser {
                 "s"
             };
 
-            let msg = format!("supplied {result_len} argument{result_plural}, but this function's signature specifies {expected_parameters_len} parameter{expected_plural} (Expected: `fn ({expected_parameters}) ...`)");
+            let msg = format!("supplied {result_len} argument{result_plural}, but this function's signature specifies {expected_parameters_len} parameter{expected_plural} (Expected arguments: `({expected_parameters})`)");
 
             errors.push(new_err(
                 child_span,

--- a/compiler/src/ast/ident.rs
+++ b/compiler/src/ast/ident.rs
@@ -61,6 +61,7 @@ pub static KEYWORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
         "or",
         "xor",
         "nil",
+        "is",
     ])
 });
 

--- a/compiler/src/ast/ident.rs
+++ b/compiler/src/ast/ident.rs
@@ -64,6 +64,23 @@ pub static KEYWORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     ])
 });
 
+impl Display for Ident {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: ", self.name)?;
+        if let Some(ref ty) = self.ty {
+            write!(f, "{ty}")
+        } else {
+            write!(f, "!!!")
+        }
+    }
+}
+
+impl Dependencies for Ident {
+    fn dependencies(&self) -> Vec<Dependency> {
+        vec![Dependency::new(Cow::Borrowed(self))]
+    }
+}
+
 impl Ident {
     pub const fn new(name: String, ty: Option<Cow<'static, TypeLayout>>, read_only: bool) -> Self {
         Self {
@@ -72,6 +89,7 @@ impl Ident {
             read_only,
         }
     }
+
     pub fn mark_const(&mut self) {
         self.read_only = true;
     }
@@ -94,6 +112,14 @@ impl Ident {
         )));
 
         Ok(self)
+    }
+
+    pub(crate) fn clone_with_type(&self, ty: Cow<'static, TypeLayout>) -> Self {
+        Self {
+            name: self.name.clone(),
+            read_only: self.read_only,
+            ty: Some(ty),
+        }
     }
 
     pub fn name(&self) -> &str {
@@ -119,26 +145,7 @@ impl Ident {
             bail!("trying to get the type of an identifier that is typeless")
         }
     }
-}
 
-impl Display for Ident {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: ", self.name)?;
-        if let Some(ref ty) = self.ty {
-            write!(f, "{ty}")
-        } else {
-            write!(f, "!!!")
-        }
-    }
-}
-
-impl Dependencies for Ident {
-    fn dependencies(&self) -> Vec<Dependency> {
-        vec![Dependency::new(Cow::Borrowed(self))]
-    }
-}
-
-impl Ident {
     pub fn set_type_no_link(&mut self, ty: Cow<'static, TypeLayout>) {
         self.ty = Some(ty);
     }

--- a/compiler/src/ast/list.rs
+++ b/compiler/src/ast/list.rs
@@ -144,11 +144,19 @@ impl ListType {
         }
     }
 
-    pub fn try_coerce_to_open(&self) -> Result<Cow<Self>> {
+    pub fn try_coerce_to_open(
+        &self,
+        comparison_flags: &TypecheckFlags<&ClassType>,
+    ) -> Result<Cow<Self>> {
         match self {
             ret @ Self::Open(..) => Ok(Cow::Borrowed(ret)),
             Self::Mixed(types) => {
-                if types.iter().as_ref().windows(2).all(|x| x[0] == x[1]) {
+                if types
+                    .iter()
+                    .as_ref()
+                    .windows(2)
+                    .all(|x| x[0].eq_complex(&x[1], comparison_flags))
+                {
                     if let Some(ty) = types.first() {
                         Ok(Cow::Owned(ListType::Open(Box::new(ty.clone()))))
                     } else {

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -37,6 +37,7 @@ pub static PRATT_PARSER: Lazy<PrattParser<Rule>> = Lazy::new(|| {
     }
 
     PrattParser::new()
+        .op(infix!(is))
         .op(infix!(unwrap))
         .op(Op::prefix(optional_unwrap))
         .op(infix!(add_assign)
@@ -86,6 +87,7 @@ pub enum Op {
     BinaryAnd,
     BitwiseLs,
     BitwiseRs,
+    Is,
 }
 
 impl Display for Op {
@@ -122,6 +124,7 @@ impl Op {
             Op::BinaryOr => "|",
             Op::BitwiseLs => "<<",
             Op::BitwiseRs => ">>",
+            Op::Is => "is",
         }
     }
 
@@ -749,6 +752,7 @@ fn parse_expr(
                 Rule::binary_xor => Op::BinaryXor,
                 Rule::bitwise_ls => Op::BitwiseLs,
                 Rule::bitwise_rs => Op::BitwiseRs,
+                Rule::is => Op::Is,
                 rule => unreachable!("Expr::parse expected infix operation, found {:?}", rule),
             };
 
@@ -852,7 +856,7 @@ fn parse_expr(
                 let lhs_ty = lhs.for_type().details(l_span.as_ref().unwrap().as_span(), &user_data.get_source_file_name(), "bad expression 1").to_err_vec()?;
 
                 let Some(function_type) = lhs_ty.is_callable() else {
-                    return Err(vec![new_err(l_span.unwrap().as_span(), &user_data.get_source_file_name(), "this is not callable".to_owned())]);
+                    return Err(vec![new_err(l_span.unwrap().as_span(), &user_data.get_source_file_name(), format!("`{lhs_ty}` is not callable"))]);
                 };
 
                 let function_arguments: Pair<Rule> = op.clone().into_inner().next().unwrap();

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    cell::Cell,
     fmt::{Debug, Display},
     rc::Rc,
 };
@@ -153,7 +154,9 @@ impl<T> UnwrapSpanDisplayable for T where T: Debug + Display {}
 pub(crate) enum Expr {
     Nil,
     Value(Value),
-    ReferenceToSelf,
+    ReferenceToSelf {
+        is_valid: Cell<bool>,
+    },
     ReferenceToConstructor(ClassType),
     UnaryMinus(Box<Expr>),
     UnaryNot(Box<Expr>),
@@ -188,6 +191,10 @@ impl Expr {
         self.for_type().map(|_| self)
     }
 
+    pub(crate) fn validate_owned(self) -> Result<Self> {
+        self.for_type().map(|_| self)
+    }
+
     pub(crate) fn parse(input: Node) -> Result<Expr, Vec<anyhow::Error>> {
         let children_as_pairs = input.children().into_pairs();
         parse_expr(children_as_pairs, input.user_data().clone())
@@ -196,7 +203,7 @@ impl Expr {
 
 impl CompileTimeEvaluate for Expr {
     fn try_constexpr_eval(&self) -> Result<ConstexprEvaluation> {
-        self.validate()?;
+        // self.validate()?;
 
         match self {
             Self::Value(val) => val.try_constexpr_eval(),
@@ -257,7 +264,7 @@ impl CompileTimeEvaluate for Expr {
 
                 Ok(ConstexprEvaluation::Owned(Value::Number(bin_op_applied?)))
             }
-            Self::ReferenceToSelf => Ok(ConstexprEvaluation::Impossible),
+            Self::ReferenceToSelf { .. } => Ok(ConstexprEvaluation::Impossible),
             Self::ReferenceToConstructor(..) => Ok(ConstexprEvaluation::Impossible),
             Self::Nil => Ok(ConstexprEvaluation::Owned(Value::nil())),
             Self::Callable { .. } => Ok(ConstexprEvaluation::Impossible),
@@ -292,7 +299,7 @@ impl CompileTimeEvaluate for Expr {
     }
 }
 
-static VOID_ERROR_MESSAGE: &str = "function returns void";
+static VOID_ERROR_MESSAGE: &str = "this scope does not yield a value";
 
 impl IntoType for Expr {
     fn for_type(&self) -> Result<super::TypeLayout> {
@@ -337,7 +344,13 @@ impl IntoType for Expr {
 
                 Ok(return_type.clone().into_owned())
             }
-            Expr::ReferenceToSelf => Ok(TypeLayout::ClassSelf),
+            Expr::ReferenceToSelf { is_valid } => {
+                if is_valid.get() {
+                    Ok(TypeLayout::ClassSelf)
+                } else {
+                    bail!("this reference to `self` is not valid here")
+                }
+            }
             Expr::ReferenceToConstructor(class_type) => {
                 Ok(TypeLayout::Function(class_type.constructor()))
             }
@@ -413,7 +426,7 @@ impl Dependencies for Expr {
                 lhs_deps
             }
             E::DotLookup { lhs, .. } => lhs.net_dependencies(),
-            E::ReferenceToSelf => vec![],
+            E::ReferenceToSelf { .. } => vec![],
             E::ReferenceToConstructor(..) => vec![],
             E::Nil => vec![],
             E::UnaryUnwrap { value, .. } => value.net_dependencies(),
@@ -560,7 +573,7 @@ fn compile_depth(
 
             Ok(lhs_compiled)
         }
-        Expr::ReferenceToSelf => Ok(vec![instruction!(load_fast "self")]),
+        Expr::ReferenceToSelf { .. } => Ok(vec![instruction!(load_fast "self")]),
         Expr::Callable(CallableContents::ToSelf { arguments, .. }) => {
             let callable = Callable::new_recursive_call(arguments);
 
@@ -638,7 +651,7 @@ fn parse_expr(
                         let raw_string = primary.as_str();
 
                         match raw_string {
-                            "self" => return Ok((Expr::ReferenceToSelf, Some(primary_pair))),
+                            "self" => return Ok((Expr::ReferenceToSelf { is_valid: Cell::new(user_data.get_type_of_executing_class().is_some()) }, Some(primary_pair))),
                             "Self" => {
                                 let class = user_data
                                 .get_type_of_executing_class()
@@ -804,7 +817,7 @@ fn parse_expr(
                 let lhs = Box::new(lhs);
 
                 match lhs.as_ref() {
-                    Expr::ReferenceToSelf => {
+                    Expr::ReferenceToSelf { is_valid } => {
                         let return_type = user_data.return_statement_expected_yield_type().map(|x| x.clone());
 
                         let function_arguments: Pair<Rule> = op.into_inner().next().unwrap();
@@ -816,6 +829,8 @@ fn parse_expr(
                             .to_err_vec()?;
 
                         let arguments: FunctionArguments = Parser::function_arguments(function_arguments, &parameters, None)?;
+
+                        is_valid.set(true);
 
                         return Ok((Expr::Callable(CallableContents::ToSelf { return_type, arguments }), l_span))
                     }
@@ -834,9 +849,9 @@ fn parse_expr(
                     _ => ()
                 }
 
-                let lhs_ty = lhs.for_type().to_err_vec()?;
+                let lhs_ty = lhs.for_type().details(l_span.as_ref().unwrap().as_span(), &user_data.get_source_file_name(), "bad expression 1").to_err_vec()?;
 
-                let Some(function_type) = lhs_ty.get_function() else {
+                let Some(function_type) = lhs_ty.is_callable() else {
                     return Err(vec![new_err(l_span.unwrap().as_span(), &user_data.get_source_file_name(), "this is not callable".to_owned())]);
                 };
 
@@ -844,22 +859,25 @@ fn parse_expr(
                 let function_arguments: Node = Node::new_with_user_data(function_arguments, Rc::clone(&user_data));
                 let function_arguments: FunctionArguments = Parser::function_arguments(function_arguments, function_type.parameters(), None)?;
 
-                Ok((Expr::Callable(CallableContents::Standard { lhs_raw: lhs, function: function_type, arguments: function_arguments }), Some(op)))
+                Ok((Expr::Callable(CallableContents::Standard { lhs_raw: lhs, function: function_type.into_owned(), arguments: function_arguments }), Some(op)))
             },
             Rule::list_index => {
-                let lhs = lhs?.0;
+                let (lhs_expr, lhs_span) = lhs?;
 
-                let lhs_ty = lhs.for_type().to_err_vec()?;
+                let lhs_span = lhs_span.unwrap().as_span();
+
+                let lhs_ty = lhs_expr.for_type().details(lhs_span, &user_data.get_source_file_name(), "bad expression 2").to_err_vec()?;
 
                 let index: Node = Node::new_with_user_data(op.clone(), Rc::clone(&user_data));
                 let index: Index = Parser::list_index(index, lhs_ty)?;
 
-                Ok((Expr::Index { lhs_raw: Box::new(lhs), index }, Some(op)))
+                Ok((Expr::Index { lhs_raw: Box::new(lhs_expr), index }, Some(op)))
             },
             Rule::dot_chain => {
-                let lhs = lhs?.0;
+                let (lhs, l_span) = lhs?;
+                let l_span = l_span.unwrap().as_span();
 
-                let lhs_ty = lhs.for_type().to_err_vec()?;
+                let lhs_ty = lhs.for_type().details(l_span, &user_data.get_source_file_name(), "bad expression 3").to_err_vec()?;
                 let lhs_ty = lhs_ty.assume_type_of_self(&user_data);
 
                 let index: Node = Node::new_with_user_data(op.clone(), Rc::clone(&user_data));
@@ -917,5 +935,13 @@ fn parse_expr(
         })
         .parse(pairs);
 
-    maybe_expr.map(|(expr, ..)| expr)
+    maybe_expr.and_then(|(expr, span)| {
+        expr.validate_owned()
+            .details(
+                span.unwrap().as_span(),
+                &user_data.get_source_file_name(),
+                "bad expression 4",
+            )
+            .to_err_vec()
+    })
 }

--- a/compiler/src/ast/value.rs
+++ b/compiler/src/ast/value.rs
@@ -131,7 +131,7 @@ impl Value {
     pub fn is_callable(&self) -> Result<bool> {
         let ty = self.for_type()?;
 
-        Ok(ty.is_function().is_some())
+        Ok(ty.is_callable().is_some())
     }
 
     pub fn associate_with_ident(&self, ident: &mut Ident, user_data: &AssocFileData) -> Result<()> {

--- a/compiler/src/ast/value.rs
+++ b/compiler/src/ast/value.rs
@@ -128,12 +128,6 @@ pub(crate) trait Indexable {
 }
 
 impl Value {
-    pub fn is_callable(&self) -> Result<bool> {
-        let ty = self.for_type()?;
-
-        Ok(ty.is_callable().is_some())
-    }
-
     pub fn associate_with_ident(&self, ident: &mut Ident, user_data: &AssocFileData) -> Result<()> {
         match self {
             Value::Function(ref f) => {

--- a/compiler/src/grammar.pest
+++ b/compiler/src/grammar.pest
@@ -54,7 +54,8 @@ bin_op = _{
     unwrap | 
     binary_xor | 
     binary_and | 
-    binary_or
+    binary_or | 
+    is
 }
 
 add = { "+" }
@@ -88,6 +89,8 @@ or = { "||" }
 xor = { "^" }
 
 unwrap = { "?=" }
+
+is = { "is" }
 
 escape_character = _{ "\\" | "r" | "n" }
 escape_sequence = @{ "\\" ~ escape_character }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -220,7 +220,7 @@ impl AssocFileData {
         self.push_scope_typed(ScopeType::Class(None), ScopeReturnStatus::No)
     }
 
-    pub fn set_self_type_of_class(&self, new_class_type: ClassType) {
+    pub fn set_self_type_of_class(&self, new_class_type: ClassType) -> ClassType {
         self.scopes.set_self_type_of_class(new_class_type)
     }
 

--- a/compiler/src/scope.rs
+++ b/compiler/src/scope.rs
@@ -3,6 +3,7 @@ use std::{
     cell::{Ref, RefCell},
     collections::{HashMap, HashSet},
     fmt::Display,
+    ops::Deref,
     rc::Rc,
 };
 
@@ -157,49 +158,31 @@ impl Scopes {
         x.last_mut().unwrap().mark_should_return_as_completed()
     }
 
-    pub(crate) fn set_self_type_of_class(&self, new_class_type: ClassType) {
+    pub(crate) fn set_self_type_of_class(&self, new_class_type: ClassType) -> ClassType {
         let mut x = self.0.borrow_mut();
 
         let last = x.last_mut().unwrap();
 
         assert!(last.is_class());
 
+        let mut fields = Vec::with_capacity(new_class_type.fields().len());
+
         for field in new_class_type.fields() {
             let ty = field.ty().unwrap();
-            if let Some(function) = ty.is_function() {
-                let (is_return_type_class_self, is_return_type_optional) = {
-                    // scoped because `try_set_return_type` borrows mutably
-                    let return_type = function.return_type();
-                    let Some(ty) = return_type.get_type() else {
-                        continue;
-                    };
-                    (
-                        ty.disregard_distractors(true).is_class_self(),
-                        ty.disregard_distractors(false).is_optional().0,
-                    )
-                };
+            let fixed = ty.update_all_references_to_class_self(new_class_type.clone());
 
-                if is_return_type_class_self {
-                    let new_class_type = new_class_type.clone();
-
-                    let mut return_type = Cow::Owned(TypeLayout::Class(new_class_type));
-
-                    if is_return_type_optional {
-                        return_type = Cow::Owned(TypeLayout::Optional(Some(Box::new(return_type))))
-                    }
-
-                    let new_return_status = ScopeReturnStatus::Did(return_type);
-
-                    function.try_set_return_type(new_return_status)
-                }
-            }
+            fields.push(field.clone_with_type(Cow::Owned(fixed)));
         }
 
         let ScopeType::Class(ref mut class_type) = last.ty else {
             unreachable!()
         };
 
-        *class_type = Some(new_class_type);
+        let new_class_type = new_class_type.with_new_fields(fields.into());
+
+        *class_type = Some(new_class_type.clone());
+
+        new_class_type
     }
 
     /// Returns the depth at which the stack is expected to be once the added frame is cleaned up.
@@ -377,10 +360,24 @@ pub(crate) enum ScopeReturnStatus {
     Did(Cow<'static, TypeLayout>),
 }
 
+#[derive(Clone)]
+struct VoidTypeWrapper(Cow<'static, TypeLayout>);
+unsafe impl Send for VoidTypeWrapper {}
+unsafe impl Sync for VoidTypeWrapper {}
+impl Deref for VoidTypeWrapper {
+    type Target = TypeLayout;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+static VOID_TYPE: VoidTypeWrapper = VoidTypeWrapper(Cow::Owned(TypeLayout::Void));
+
 impl ScopeReturnStatus {
     pub fn get_type(&self) -> Option<&Cow<'static, TypeLayout>> {
         match self {
             Self::Did(x) | Self::ParentShould(x) | Self::Should(x) => Some(x),
+            Self::Void => Some(&VOID_TYPE.0),
             _ => None,
         }
     }
@@ -395,7 +392,7 @@ impl ScopeReturnStatus {
         };
 
         use crate::ast::TypecheckFlags;
-        Ok(lhs.eq_complex(rhs, &TypecheckFlags::<&ClassType>::classless()))
+        Ok(lhs.eq_complex(rhs.as_ref(), &TypecheckFlags::<&ClassType>::classless()))
     }
 
     pub fn detect_should_return(val: Option<Cow<'static, TypeLayout>>) -> Self {

--- a/compiler/src/scope.rs
+++ b/compiler/src/scope.rs
@@ -360,6 +360,16 @@ pub(crate) enum ScopeReturnStatus {
     Did(Cow<'static, TypeLayout>),
 }
 
+impl Display for ScopeReturnStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Void => write!(f, "void"),
+            Self::No => write!(f, "!never"),
+            Self::Should(x) | Self::ParentShould(x) | Self::Did(x) => write!(f, "{x}"),
+        }
+    }
+}
+
 #[derive(Clone)]
 struct VoidTypeWrapper(Cow<'static, TypeLayout>);
 unsafe impl Send for VoidTypeWrapper {}

--- a/compiler/src/tests/math.rs
+++ b/compiler/src/tests/math.rs
@@ -292,3 +292,31 @@ fn bit_ops() {
     )
     .unwrap()
 }
+
+#[test]
+fn is_operator() {
+    eval(
+        r#"
+		assert 5 is 5
+		assert 0b101 is 5
+		assert 0b101.abs() is (-5).abs()
+
+		class A {}
+
+		a1 = A()
+		a2 = A()
+		a3 = a1
+
+		assert !(a1 is a2)
+		assert a1 is a3
+
+		const v1 = [1, 2, 3]
+		const v2 = [1, 2, 3]
+		const v3 = v2
+
+		assert !(v1 is v2)
+		assert v2 is v3
+	"#,
+    )
+    .unwrap();
+}

--- a/compiler/src/tests/modules.rs
+++ b/compiler/src/tests/modules.rs
@@ -154,8 +154,8 @@ fn import_name() {
         assert cat1.cuteness == cat2.cuteness
         assert pup1.name == pup2.name
 
-        assert Cat == kitties.Cat
-        assert Dog == doggies.Dog
+        assert Cat is kitties.Cat
+        assert Dog is doggies.Dog
     "#,
     )
     .unwrap()
@@ -167,6 +167,9 @@ fn import_name() {
                 self.name = name
             }
             name: str
+            fn eq(self, other: Self) -> bool {
+                return self.name == other.name
+            }
         }
     "#,
     )
@@ -178,6 +181,9 @@ fn import_name() {
             cuteness: int
             constructor(self, cuteness: int) {
                 self.cuteness = cuteness
+            }
+            fn eq(self, other: Self) -> bool {
+                return self.cuteness == other.cuteness
             }
         }
     "#,

--- a/examples/crashes/try_to_crash.DEBUG_EMIT.mmm
+++ b/examples/crashes/try_to_crash.DEBUG_EMIT.mmm
@@ -1,0 +1,32 @@
+function A::$constructor
+	arg 0
+	store self
+	void
+	ret
+end
+function A
+	make_object
+	store_fast #1
+	make_function ./try_to_crash.mmm#A::$constructor
+	store_fast #0
+	load_fast #1
+	load_fast #0
+	call
+	load_fast #1
+	ret
+end
+function __module__
+	make_function ./try_to_crash.mmm#A
+	export_special A A
+	load A
+	store_fast #1
+	load_fast #1
+	call
+	store a
+	load a
+	store_fast #1
+	load_fast #1
+	call
+	void
+	ret_mod
+end

--- a/examples/crashes/try_to_crash.ms
+++ b/examples/crashes/try_to_crash.ms
@@ -1,8 +1,3 @@
-class A {}
-a = A()
-a()
-
-###
 class A {
 	field: [Self?...]?
 
@@ -24,9 +19,8 @@ a = A()
 type B A
 b = A()
 
-a.set_field([a, b(), A()])
+a.set_field([a, b, A()])
 
-print a
-print a.to_str()
 print a.equ(get (get a.field)[0])
-###
+print a is (get a.field)[0]
+print a is get (get a.field)[0]

--- a/examples/crashes/try_to_crash.ms
+++ b/examples/crashes/try_to_crash.ms
@@ -1,60 +1,32 @@
-class Dog {
-	name: str
-	constructor(self, name: str) {
-		self.name = name
+class A {}
+a = A()
+a()
+
+###
+class A {
+	field: [Self?...]?
+
+	fn set_field(self, field: [Self...]) {
+		self.field = field
 	}
+
 	fn to_str(self) -> str {
-		return "Dog named " + self.name
+		return "A { field: " + self.field.to_str() + " }"
+	}
+
+	fn equ(self, rhs: Self) -> bool {
+		return self.field == rhs.field
 	}
 }
 
-class Cat {
-	name: str
-	breed: str
-	constructor(self, name: str, breed: str) {
-		self.name = name
-		self.breed = breed
-	}
-	fn to_str(self) -> str {
-		return "Cat named " + self.name + " is a " + self.breed
-	}
-}
+a = A()
 
-dogs: [Dog...] = [Dog("Old Yeller"), Dog("Air Bud"), Dog("Odie")]
+type B A
+b = A()
 
-dogs.push(Dog("Scout"))
-dogs.push(Dog("Muna"))
+a.set_field([a, b(), A()])
 
-assert dogs.len() == 5
-assert (dogs[3]).name == "Scout"
-
-dogs_str: [str...] = []
-from 0 to dogs.len(), i {
-	dogs_str.push((dogs[i]).to_str() + ": " + typeof dogs[i])
-}
-
-assert dogs_str == ["Dog named Old Yeller: Dog", "Dog named Air Bud: Dog", "Dog named Odie: Dog", "Dog named Scout: Dog", "Dog named Muna: Dog"]
-
-dogs.reverse()
-
-maybe_dogs = dogs.map(fn(x: Dog) -> Dog? { return x })
-
-assert typeof maybe_dogs == "[Dog?...]"
-assert dogs == maybe_dogs
-
-maybe_dogs_str: [str...] = []
-
-from 0 to maybe_dogs.len(), i {
-	maybe_dogs_str.push((maybe_dogs[i]).to_str() + ": " + typeof maybe_dogs[i])
-}
-
-assert maybe_dogs_str == ["Dog named Muna: Dog?", "Dog named Scout: Dog?", "Dog named Odie: Dog?", "Dog named Air Bud: Dog?", "Dog named Old Yeller: Dog?"]
-
-cats = maybe_dogs.map(fn(x: Dog?) -> Cat { return Cat((get x).name, "tabby") })
-
-cats_str: [str...] = []
-from 0 to cats.len(), i {
-	cats_str.push((cats[i]).to_str() + ": " + typeof cats[i])
-}
-
-assert cats_str == ["Cat named Muna is a tabby: Cat", "Cat named Scout is a tabby: Cat", "Cat named Odie is a tabby: Cat", "Cat named Air Bud is a tabby: Cat", "Cat named Old Yeller is a tabby: Cat"]
+print a
+print a.to_str()
+print a.equ(get (get a.field)[0])
+###


### PR DESCRIPTION
- Added `is` operator (works on `Object`, `Module`, `Vec`, and falls back onto `==`)
  ```py
  a = [1, 2, 3]
  b = [1, 2, 3]
  c = a

  print a == b # true
  print a is b # false
  print a == c # true
  print a is c # true
  ```
- Fixed bug with `Optional` and `ClassSelf` not being handled properly by the typechecker in lists (#177)
- Fixed runtime crash where a `Class` instance was passed to a standard `call` instruction because the compiler thought it was the class' constructor, and marked it as callable.
  ```py
  class A {}
  a = A()
  a() # << HERE -- fixed
  ```