### PR TITLE
181 bug types are not enforced in child scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ name = "bytecode"
 version = "1.0.0-rc.3"
 dependencies = [
  "anyhow",
+ "casey",
  "lazy_static",
  "libloading",
  "log",
@@ -89,6 +90,15 @@ dependencies = [
  "anyhow",
  "bytecode",
  "indicatif",
+]
+
+[[package]]
+name = "casey"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614586263949597dcc18675da12ef9b429135e13628d92eb8b8c6fa50ca5656b"
+dependencies = [
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/bytecode/Cargo.toml
+++ b/bytecode/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0.69"
+casey = "0.4.0"
 lazy_static = "1.4.0"
 libloading = "0.8.0"
 log = "0.4.19"

--- a/bytecode/src/function.rs
+++ b/bytecode/src/function.rs
@@ -13,7 +13,8 @@ use std::rc::{Rc, Weak};
 use crate::compilation_bridge::raw_byte_instruction_to_string_representation;
 use crate::context::{Ctx, SpecialScope};
 use crate::file::MScriptFile;
-use crate::instruction::{run_instruction, Instruction, JumpRequestDestination};
+use crate::instruction::{Instruction, JumpRequestDestination};
+use crate::instruction_constants::query;
 
 use super::instruction::JumpRequest;
 use super::stack::{Stack, VariableMapping};
@@ -1242,7 +1243,7 @@ impl Function {
 
             // queries the function pointer associated with the instruction,
             // and gives it ownership of the instruction.
-            run_instruction(&mut context, instruction)
+            query!(&mut context, instruction)
                 .context("failed to run instruction")
                 .with_context(|| {
                     let instruction_as_str =

--- a/bytecode/src/instruction.rs
+++ b/bytecode/src/instruction.rs
@@ -2,7 +2,6 @@
 
 use super::context::Ctx;
 use super::function::InstructionExitState;
-use super::instruction_constants;
 use super::stack::{Stack, VariableMapping};
 use super::variables::{ObjectBuilder, Primitive};
 use anyhow::{bail, Context, Result};
@@ -34,18 +33,7 @@ pub mod implementations {
     use std::collections::HashMap;
     use std::rc::Rc;
 
-    pub(crate) fn constexpr(ctx: &mut Ctx, args: &[String]) -> Result<()> {
-        if args.len() != 1 {
-            bail!("unexpected 1 parameter")
-        }
-
-        let var = Primitive::from(args[0].as_str());
-
-        ctx.push(var);
-
-        Ok(())
-    }
-
+    #[inline(always)]
     pub(crate) fn pop(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if !args.is_empty() {
             bail!("unexpected parameter")
@@ -56,6 +44,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn stack_dump(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         println!("====== Start Context Dump ======");
         'get_data: {
@@ -93,6 +82,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn neg(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         let Some(val) = ctx.get_last_op_item_mut() else {
             bail!("neg requires one item on the local operating stack")
@@ -103,6 +93,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn not(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         let Some(val) = ctx.get_last_op_item_mut() else {
             bail!("not requires one item on the local operating stack")
@@ -117,6 +108,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn bin_op(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         use Primitive::*;
         let symbols = args
@@ -162,6 +154,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn bin_op_assign(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let op = args
             .first()
@@ -222,6 +215,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn ptr_mut(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         if ctx.stack_size() < 2 {
             bail!(
@@ -242,6 +236,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn vec_op(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let mut arg_iter = args.iter();
         let op_name = arg_iter.next().context("Expected a vector operation")?;
@@ -368,31 +363,18 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn nop(_: &mut Ctx, _: &[String]) -> Result<()> {
         bail!("nop/0x00 (null) instructions are usually signs of the runtime incorrectly loading a function. This instruction will never be emitted by the compiler")
     }
 
-    pub(crate) fn len(ctx: &mut Ctx, _: &[String]) -> Result<()> {
-        let Some(top) = ctx.pop() else {
-            bail!("len requires an item on the local stack")
-        };
-
-        let result = match top {
-            Primitive::Vector(v) => int!(v.borrow().len().try_into()?),
-            Primitive::Str(s) => int!(s.len().try_into()?),
-            _ => bail!("cannot get the raw length of a non-string/vector"),
-        };
-
-        ctx.push(result);
-
-        Ok(())
-    }
-
+    #[inline(always)]
     pub(crate) fn void(ctx: &mut Ctx, _: &[String]) -> Result<()> {
         ctx.clear_stack();
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn breakpoint(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if cfg!(feature = "skip_breakpoint") {
             return Ok(());
@@ -419,6 +401,7 @@ pub mod implementations {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn ret(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         if ctx.stack_size() > 1 {
             bail!("ret can only return a single item");
@@ -437,6 +420,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn ret_mod(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         if ctx.stack_size() != 0 {
             bail!("ret_mod should have a clean operating stack");
@@ -451,6 +435,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_bool(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.len() != 1 {
             bail!("expected 1 parameter")
@@ -463,6 +448,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_int(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.len() != 1 {
             bail!("expected 1 parameter")
@@ -475,6 +461,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_float(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.len() != 1 {
             bail!("expected 1 parameter")
@@ -487,6 +474,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_byte(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.len() != 1 {
             bail!("expected 1 parameter")
@@ -499,6 +487,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_bigint(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.len() != 1 {
             bail!("expected 1 parameter")
@@ -511,6 +500,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_str(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let raw_str = match args.len() {
             0 => "",
@@ -525,6 +515,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_function(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(location) = args.first() else {
             bail!("making a function pointer requires a path to find it")
@@ -557,6 +548,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_object(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if !args.is_empty() {
             bail!("`make_object` does not require arguments")
@@ -607,6 +599,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn make_vector(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.len() > 1 {
             bail!("`make_vector` instruction requires 1 argument (capacity) or none (initializes with contents of local operating stack)")
@@ -632,6 +625,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn printn(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(arg) = args.first() else {
             bail!("expected 1 parameter (index into local operating stack), or * to print all");
@@ -671,6 +665,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn call_object(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let path = args.last().context("missing method name argument")?;
 
@@ -697,6 +692,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn mutate(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let var_name = args
             .first()
@@ -729,6 +725,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn call(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(first) = args.first() else {
             let last = ctx.pop();
@@ -788,6 +785,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn call_self(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         let arguments = ctx.get_local_operating_stack().clone();
 
@@ -815,6 +813,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn module_entry(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(first) = args.first() else {
             bail!("expected one argument");
@@ -834,6 +833,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn split_lookup_store(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(top) = ctx.get_last_op_item() else {
             bail!("`split_lookup_store` expected an item at the top of the operating stack");
@@ -858,6 +858,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn arg(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(first) = args.first() else {
             bail!("expected one argument")
@@ -876,6 +877,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn stack_size(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         let size = int!(ctx.frames_count().try_into()?);
         ctx.push(size);
@@ -883,11 +885,13 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn reserve_primitive(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         ctx.push(optional!(empty));
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn unwrap_into(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("`unwrap_into` requires a name");
@@ -926,6 +930,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn unwrap(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(primitive) = ctx.get_last_op_item_mut() else {
             bail!("`unwrap` requires a primitive at the top of the local operating stack");
@@ -946,6 +952,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn jmp_not_nil(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(primitive) = ctx.get_last_op_item_mut() else {
             bail!("`jmp_not_nil` requires a primitive at the top of the local operating stack");
@@ -969,6 +976,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn store(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("`store` requires a name")
@@ -990,6 +998,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn export_name(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("`export_name` requires a name")
@@ -1005,6 +1014,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn load_self_export(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(src) = args.first() else {
             bail!("`load_self_export` requires a source name")
@@ -1021,6 +1032,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn export_special(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("`export_special` requires a name")
@@ -1046,6 +1058,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn store_fast(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("store_fast requires a name")
@@ -1063,6 +1077,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn store_object(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("store_object requires a name")
@@ -1080,6 +1096,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn store_skip(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some([name, predicate, lines_to_jump]) = args.get(0..=2) else {
             bail!("store_skip: name:str predicate:u8(1/0) lines_to_jump:isize")
@@ -1128,6 +1146,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn fast_rev2(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         if ctx.stack_size() != 2 {
             bail!("fast_rev2 requires a stack size of 2");
@@ -1143,6 +1162,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn load(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("load requires a name")
@@ -1160,6 +1181,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn load_fast(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("load requires a name")
@@ -1171,6 +1194,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn load_callback(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("loading a callback variable requires one parameter: (name)")
@@ -1183,6 +1208,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn delete_name_scoped(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.is_empty() {
             bail!("delete_name_scoped requires names to delete")
@@ -1194,6 +1220,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn delete_name_reference_scoped(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if args.len() != 1 {
             bail!("delete_name_reference_scoped can only delete to retrieve one name");
@@ -1208,6 +1236,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn lookup(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if ctx.stack_size() != 1 {
             bail!(
@@ -1237,6 +1267,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn ld_self(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(name) = args.first() else {
             bail!("`ld_self` requires a name argument");
@@ -1249,6 +1280,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn assert(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if ctx.stack_size() != 1 {
             bail!("assert can only operate on a single item");
@@ -1267,34 +1299,7 @@ pub mod implementations {
         Ok(())
     }
 
-    pub(crate) fn typecmp(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
-        if ctx.stack_size() != 2 {
-            bail!("typecmp requires only 2 items in the local stack")
-        }
-
-        let first = ctx.pop().unwrap();
-        let second = ctx.pop().unwrap();
-
-        let cmp = first.ty() == second.ty();
-
-        ctx.push(bool!(cmp));
-
-        Ok(())
-    }
-    pub(crate) fn strict_equ(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
-        if ctx.stack_size() != 2 {
-            bail!("equ requires only 2 items in the local stack")
-        }
-
-        let first = ctx.pop().unwrap().move_out_of_heap_primitive();
-        let second = ctx.pop().unwrap().move_out_of_heap_primitive();
-
-        let result = first == second;
-
-        ctx.push(bool!(result));
-
-        Ok(())
-    }
+    #[inline(always)]
     pub(crate) fn equ(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         if ctx.stack_size() != 2 {
             bail!("equ requires only 2 items in the local stack")
@@ -1309,6 +1314,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn neq(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         if ctx.stack_size() != 2 {
             bail!("neq requires only 2 items in the local stack");
@@ -1324,6 +1331,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn if_stmt(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if ctx.stack_size() == 0 {
             bail!("if statements require at least one entry in the local stack")
@@ -1348,6 +1356,8 @@ pub mod implementations {
 
         Ok(())
     }
+
+    #[inline(always)]
     pub(crate) fn while_loop(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         if ctx.stack_size() == 0 {
             bail!("while statements require at least one entry in the local stack")
@@ -1373,6 +1383,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn jmp(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(offset) = args.first() else {
             bail!("jmp statements require an argument to instruct where to jump")
@@ -1383,6 +1394,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn jmp_pop(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let Some(offset) = args.first() else {
             bail!("jmp_pop statements require an argument to instruct where to jump")
@@ -1400,6 +1412,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn done(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         log::trace!("DONE & POP");
         ctx.signal(InstructionExitState::PopScope);
@@ -1407,6 +1420,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn else_stmt(ctx: &mut Ctx, _args: &[String]) -> Result<()> {
         log::trace!("PUSH ELSE");
 
@@ -1415,6 +1429,7 @@ pub mod implementations {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn call_lib(ctx: &mut Ctx, args: &[String]) -> Result<()> {
         let (Some(lib_name), Some(func_name)) = (args.first(), args.get(1)) else {
             bail!("expected syntax: call_lib path/to/lib.dll function_name")
@@ -1435,19 +1450,6 @@ pub mod implementations {
         ctx.clear_stack();
         Ok(())
     }
-}
-
-/// Get a function pointer to the bytecode instruction associated with a byte.
-pub fn query(byte: u8) -> InstructionSignature {
-    instruction_constants::FUNCTION_POINTER_LOOKUP[byte as usize]
-}
-
-/// Run an instruction.
-#[inline(always)]
-pub fn run_instruction(ctx: &mut Ctx, instruction: &Instruction) -> Result<()> {
-    let instruction_fn = query(instruction.id);
-    instruction_fn(ctx, &instruction.arguments)?;
-    Ok(())
 }
 
 /// Parse a string into tokens based on preset rules.
@@ -1598,7 +1600,7 @@ pub struct Instruction {
     /// for valid identities.
     pub id: u8,
     /// The arguments to the instruction.
-    arguments: Box<[String]>,
+    pub(crate) arguments: Box<[String]>,
 }
 
 impl Instruction {

--- a/bytecode/src/lib.rs
+++ b/bytecode/src/lib.rs
@@ -46,7 +46,7 @@ pub mod compilation_bridge {
     /// assert_eq!(update, &0x28);
     /// ```
     pub fn string_instruction_representation_to_byte(string: &str) -> Option<&u8> {
-        REPR_TO_BIN.get(string.as_bytes())
+        REPR_TO_BIN.get(string)
     }
 
     /// Reverse an instruction from its byte to its name.
@@ -64,9 +64,8 @@ pub mod compilation_bridge {
     /// ```
     pub fn raw_byte_instruction_to_string_representation(byte: u8) -> Option<Cow<'static, str>> {
         let byte_string = BIN_TO_REPR.get(byte as usize)?;
-        let as_str = String::from_utf8_lossy(byte_string);
-
-        Some(as_str)
+        // let as_str = String::from_utf8_lossy(byte_string);
+        Some(Cow::Borrowed(byte_string))
     }
 }
 

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -318,7 +318,7 @@ macro_rules! instruction {
         use $crate::ast::*;
 
         let id = bytecode::compilation_bridge::string_instruction_representation_to_byte(stringify!($name))
-            .expect("instruction does not exist");
+            .unwrap_or_else(|| panic!("instruction `{}` does not exist", stringify!($name)));
 
         let arguments = vec![
             $(

--- a/compiler/src/ast/boolean.rs
+++ b/compiler/src/ast/boolean.rs
@@ -4,7 +4,7 @@ use super::{r#type::IntoType, CompilationState, Compile, Dependencies};
 
 impl Compile for bool {
     fn compile(&self, _: &CompilationState) -> anyhow::Result<Vec<super::CompiledItem>> {
-        Ok(vec![instruction!(bool self)])
+        Ok(vec![instruction!(make_bool self)])
     }
 }
 

--- a/compiler/src/ast/if_statement.rs
+++ b/compiler/src/ast/if_statement.rs
@@ -52,7 +52,7 @@ impl Compile for IfStatement {
 
         let if_size = body_init.len() + if self.else_statement.is_some() { 2 } else { 1 };
 
-        result.push(instruction!(if if_size));
+        result.push(instruction!(if_stmt if_size));
 
         // result:
         //  - value_init...
@@ -106,7 +106,7 @@ impl Compile for ElseStatement {
             Self::IfStatement(if_statement) => if_statement.compile(state),
         }?;
 
-        content.insert(0, instruction!(else));
+        content.insert(0, instruction!(else_stmt));
         content.push(instruction!(done));
 
         Ok(content)

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -617,7 +617,7 @@ fn compile_depth(
 
             Ok(value_compiled)
         }
-        Expr::Typeof(_, name) => Ok(vec![instruction!(string name)]),
+        Expr::Typeof(_, name) => Ok(vec![instruction!(make_str name)]),
     }
 }
 

--- a/compiler/src/ast/number.rs
+++ b/compiler/src/ast/number.rs
@@ -294,10 +294,10 @@ impl IntoType for Number {
 impl Compile for Number {
     fn compile(&self, _: &CompilationState) -> Result<Vec<CompiledItem>> {
         let matched = match self {
-            Number::Byte(val) => vec![instruction!(byte val)],
-            Number::Float(val) => vec![instruction!(float val)],
-            Number::Integer(val) => vec![instruction!(int val)],
-            Number::BigInt(val) => vec![instruction!(bigint val)],
+            Number::Byte(val) => vec![instruction!(make_byte val)],
+            Number::Float(val) => vec![instruction!(make_float val)],
+            Number::Integer(val) => vec![instruction!(make_int val)],
+            Number::BigInt(val) => vec![instruction!(make_bigint val)],
         };
 
         Ok(matched)

--- a/compiler/src/ast/string.rs
+++ b/compiler/src/ast/string.rs
@@ -42,7 +42,7 @@ impl IntoType for AstString {
 impl Compile for AstString {
     fn compile(&self, _: &CompilationState) -> Result<Vec<CompiledItem>> {
         match self {
-            AstString::Plain(content) => Ok(vec![instruction!(string content)]),
+            AstString::Plain(content) => Ok(vec![instruction!(make_str content)]),
             AstString::FormattedString() => todo!(),
         }
     }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -351,8 +351,19 @@ impl AssocFileData {
         self.get_dependency_flags_from_name(dependency).is_some()
     }
 
-    pub fn has_name_been_mapped_local(&self, dependency: &str) -> bool {
-        self.get_ident_from_name_local(dependency).is_some()
+    pub fn has_name_been_mapped_in_function(&self, dependency: &str) -> Option<Ident> {
+        for scope in self.scopes.iter() {
+            let maybe_result = scope.contains(dependency);
+            if maybe_result.is_some() {
+                return maybe_result.cloned();
+            }
+
+            if scope.is_function() {
+                break;
+            }
+        }
+
+        None
     }
 
     pub fn get_ident_from_name_local(&self, dependency: &str) -> Option<Ref<Ident>> {

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -4,6 +4,7 @@
 //! ```
 
 mod assertions;
+mod assignments;
 mod builtins;
 mod class;
 mod comments;

--- a/compiler/src/tests/assignments.rs
+++ b/compiler/src/tests/assignments.rs
@@ -1,0 +1,237 @@
+use crate::{eval, EvalEnvironment};
+
+/// To update a variable, just write:
+///
+/// a = 20
+///
+/// The "modify" keyword will try to update a variable capture, which
+/// does not exist at the module level.
+#[test]
+#[should_panic = "this assignment contains the \"modify\" attribute, which is used to mutate a variable from a higher scope"]
+fn modify_misuse() {
+    eval(
+        r#"
+		a = 10
+		modify a = 20
+	"#,
+    )
+    .unwrap()
+}
+
+#[test]
+#[should_panic = "attempting to reassign to a const variable"]
+fn attempt_const_bypass_1() {
+    eval(
+        r#"
+		const a = 5
+
+		if true {
+			a = 7
+		}
+		
+		assert typeof a == "int"
+		assert a == 5 
+
+		assert false
+	"#,
+    )
+    .unwrap()
+}
+
+#[test]
+#[should_panic = "attempting to reassign to a const variable"]
+fn attempt_const_bypass_2() {
+    eval(
+        r#"
+		const a = 5
+
+		fn() {
+			modify a = 7
+		}()
+		
+		assert typeof a == "int"
+		assert a == 5 
+
+		assert false
+	"#,
+    )
+    .unwrap()
+}
+
+#[test]
+#[should_panic = "attempting to reassign to a const variable"]
+fn attempt_const_bypass_3() {
+    eval(
+        r#"
+		const a = 5
+
+		fn() {
+			modify a = 7
+		}()
+		
+		assert typeof a == "int"
+		assert a == 5 
+
+		assert false
+	"#,
+    )
+    .unwrap()
+}
+
+#[test]
+#[should_panic = "attempting to reassign to a const variable"]
+fn attempt_const_bypass_4() {
+    EvalEnvironment::entrypoint(
+        "main.ms",
+        r#"
+		import book
+		book = 5
+	"#,
+    )
+    .unwrap()
+    .add("book.ms", "")
+    .unwrap()
+    .run()
+    .unwrap();
+}
+
+#[test]
+#[should_panic = "The target of this assignment is const, and cannot be modified"]
+fn attempt_const_bypass_5() {
+    EvalEnvironment::entrypoint(
+        "main.ms",
+        r#"
+		import book
+		book.favorite = "Harry Potter"
+	"#,
+    )
+    .unwrap()
+    .add(
+        "book.ms",
+        r#"
+		export const favorite: str = "The Kite Runner"
+	"#,
+    )
+    .unwrap()
+    .run()
+    .unwrap();
+}
+
+#[test]
+fn not_import_const_bypass() {
+    EvalEnvironment::entrypoint(
+        "main.ms",
+        r#"
+		import favorite from book
+		import book
+
+		favorite = "Harry Potter"
+
+		assert book.favorite == "The Kite Runner"
+
+		assert favorite == "Harry Potter"
+	"#,
+    )
+    .unwrap()
+    .add(
+        "book.ms",
+        r#"
+		export const favorite: str = "The Kite Runner"
+	"#,
+    )
+    .unwrap()
+    .run()
+    .unwrap();
+}
+
+#[test]
+#[should_panic = "type mismatch: this assignment will update a variable with type `str`, which is not compatible with the original type `int`"]
+fn attempt_type_bypass_1() {
+    eval(
+        r#"
+		a = 5
+
+		while true {
+			a = "hello"
+			break
+		}
+	"#,
+    )
+    .unwrap()
+}
+
+#[test]
+#[should_panic = "type mismatch: this assignment will update a variable with type `str`, which is not compatible with the original type `int`"]
+fn attempt_type_bypass_2() {
+    eval(
+        r#"
+		a = 5
+
+		fn() {
+			a = [1, 2, 3].map(fn (x: int) -> int {
+					return x
+				})
+			# ^ okay because a is exclusive to this scope,
+			#   and not a captured reference.
+		}
+
+		fn() {
+			modify a = "hello"
+		}()
+	"#,
+    )
+    .unwrap()
+}
+
+#[test]
+#[should_panic = "this unpack operation shadows one or more names accesible from this scope, starting at `set_text`"]
+fn attempt_type_bypass_3() {
+    eval(
+        r#"
+		const use_text = fn(initial: str) -> [fn() -> str, fn(str)] {
+			return [
+				fn() -> str {
+					return initial
+				},
+				fn(new_text: str) {
+					modify initial = new_text
+				} 
+			]
+		}
+
+		set_text = fn() {
+			print "hello world!"
+		}
+
+		print typeof set_text
+
+		if true {
+			[get_text, set_text] = use_text("Guest")
+		}
+
+		assert get_text() == "Guest"
+		set_text() # which `set_text` is valid?
+		assert get_text() == "@mrod"
+		print typeof set_text
+	"#,
+    )
+    .unwrap()
+}
+
+#[test]
+#[should_panic = "this name shadows a variable with type `str` in a higher scope, but this iteration construct yields `int` and is not compatible"]
+fn attempt_type_bypass_4() {
+    eval(
+        r#"
+		a = "hello"
+
+		from 1 to 10, a {
+			print a
+		}
+
+		print a
+		print typeof a
+	"#,
+    )
+    .unwrap()
+}

--- a/compiler/src/tests/builtins.rs
+++ b/compiler/src/tests/builtins.rs
@@ -17,19 +17,19 @@ fn list_random() {
 	
 		take_ints(x)
 	
-		x: [int...] = [1, 2, 3, 4, 5]
+		y: [int...] = [1, 2, 3, 4, 5]
 		
-		assert x == [1, 2, 3, 4, 5]
+		assert y == [1, 2, 3, 4, 5]
 
-		x.reverse()
+		y.reverse()
 
-		assert x == [5, 4, 3, 2, 1]
+		assert y == [5, 4, 3, 2, 1]
 	
-		assert x.inner_capacity() >= 5
+		assert y.inner_capacity() >= 5
 	
-		x.ensure_inner_capacity(100)
+		y.ensure_inner_capacity(100)
 	
-		assert x.inner_capacity() >= 105
+		assert y.inner_capacity() >= 105
 	"#,
     )
     .unwrap();
@@ -74,19 +74,19 @@ fn open_list_type() {
 		assert typeof x == "[int...]"
 		assert typeof x[3] == "int"
 
-		x = x.map(fn(in: int) -> str {
+		x_as_str = x.map(fn(in: int) -> str {
 			return in + "!"
 		})
 
-		assert typeof x == "[str...]"
+		assert typeof x_as_str == "[str...]"
 
-		assert x == ["16!", "9999999!", "5!", "60!"]
+		assert x_as_str == ["16!", "9999999!", "5!", "60!"]
 		
-		x = x.join(["hello", "world"])
+		x_as_str = x_as_str.join(["hello", "world"])
 
-		assert typeof x[0] == "str"
+		assert typeof x_as_str[0] == "str"
 
-		assert x == ["16!", "9999999!", "5!", "60!", "hello", "world"]
+		assert x_as_str == ["16!", "9999999!", "5!", "60!", "hello", "world"]
 	"#,
     )
     .unwrap();

--- a/compiler/src/tests/types.rs
+++ b/compiler/src/tests/types.rs
@@ -207,6 +207,7 @@ fn types_with_reassignment() {
 }
 
 #[test]
+#[ignore = "2/4/2024 - type updates are no longer in spec"]
 fn type_updates() {
     eval(
         r#"
@@ -225,6 +226,7 @@ fn type_updates() {
 
 /// `2` is an invalid index into "hi", so this test asserts that types and values are being updated
 #[test]
+#[ignore = "2/4/2024 - type updates are no longer in spec"]
 fn type_updates_index() {
     eval(
         r#"

--- a/examples/crashes/try_to_crash.DEBUG_EMIT.mmm
+++ b/examples/crashes/try_to_crash.DEBUG_EMIT.mmm
@@ -1,32 +1,21 @@
-function A::$constructor
-	arg 0
-	store self
-	void
-	ret
-end
-function A
-	make_object
-	store_fast #1
-	make_function ./try_to_crash.mmm#A::$constructor
-	store_fast #0
-	load_fast #1
-	load_fast #0
-	call
-	load_fast #1
-	ret
-end
 function __module__
-	make_function ./try_to_crash.mmm#A
-	export_special A A
-	load A
-	store_fast #1
-	load_fast #1
-	call
-	store a
-	load a
-	store_fast #1
-	load_fast #1
-	call
+	int 1
+	store_fast i
+	int 3
+	store_fast L#1
+	load_fast i
+	load_fast L#1
+	bin_op <=
+	while_loop 10
+	int 10
+	bin_op_assign *= i
 	void
+	load i
+	printn *
+	void
+	int 1
+	bin_op_assign += i
+	jmp_pop -12
+	delete_name_scoped i L#1
 	ret_mod
 end

--- a/examples/crashes/try_to_crash.mmm
+++ b/examples/crashes/try_to_crash.mmm
@@ -1,0 +1,15 @@
+function __module__
+	int 1
+	store_fast L#1
+	int 10000000
+	store_fast L#2
+	load_fast L#1
+	load_fast L#2
+	bin_op <
+	while_loop 4
+	int 1
+	bin_op_assign += L#1
+	jmp_pop -6
+	delete_name_scoped L#1 L#2
+	ret_mod
+end

--- a/examples/crashes/try_to_crash.ms
+++ b/examples/crashes/try_to_crash.ms
@@ -1,26 +1,8 @@
-class A {
-	field: [Self?...]?
+a = "hello"
 
-	fn set_field(self, field: [Self...]) {
-		self.field = field
-	}
-
-	fn to_str(self) -> str {
-		return "A { field: " + self.field.to_str() + " }"
-	}
-
-	fn equ(self, rhs: Self) -> bool {
-		return self.field == rhs.field
-	}
+from 1 to 10, a {
+	print a
 }
 
-a = A()
-
-type B A
-b = A()
-
-a.set_field([a, b, A()])
-
-print a.equ(get (get a.field)[0])
-print a is (get a.field)[0]
-print a is get (get a.field)[0]
+print a
+print typeof a

--- a/examples/crashes/try_to_crash.ms
+++ b/examples/crashes/try_to_crash.ms
@@ -1,8 +1,4 @@
-a = "hello"
+# pre: Program terminated in 0.55725044s
+from 1 to 10_000_000 {
 
-from 1 to 10, a {
-	print a
 }
-
-print a
-print typeof a


### PR DESCRIPTION
- Fixes #181 
- Removes support for variable-typed names. It originally crept as a bug, was soft-fixed by part of #167, but is now a hard error.
  - Fixed buggy unit tests
- Added unit tests for new failures
- Changed the way instructions are executed, from a function pointer lookup to inlined code (f0cdad3f30f33c6406eeaa111fcc4858eedae412). I will record performance over the next few weeks to see if it has a meaningful positive impact.